### PR TITLE
in compute L2, allow for cases where both waveforms are identically zero

### DIFF
--- a/Pipeline/EMD_matlab/emd_nt.m
+++ b/Pipeline/EMD_matlab/emd_nt.m
@@ -49,6 +49,7 @@ function [x, fval, L2] = emd_nt(F1, F2, W1, W2, mw1, mw2, chan_pos, dim_mask, l2
 
 % ground distance matrix
 [f,L2] = gdm_nt(F1, F2, mw1, mw2, chan_pos, dim_mask, l2_weight, xStep, zStep, Func);
+% save('gnd_dist.mat','f','-v7.3');
 % fprintf('f = %d, L2 = %d\n', f, L2);
 
 % number of feature vectors

--- a/Pipeline/create_input/wf_metric/calcCenteredCorrL2.m
+++ b/Pipeline/create_input/wf_metric/calcCenteredCorrL2.m
@@ -44,12 +44,15 @@ for i = 1:numel(zIncl(1,:)) %row loop = 11
         cX2 = chan_pos(cc2(j));
         %corr of matching sites
         if (cX1 < mid_point && cX2 < mid_point) || (cX1 > mid_point && cX2 > mid_point)%ismember(cX, cc2_xPos)
-            nSite = nSite + 1;
             wf1 = mw1(cc1(j),:);
             wf2 = mw2(cc2(j),:);
-            % commenting out correlation; not currently used
-            % cv = cv + corr(wf1',wf2');  % remove correlation calculation
-            cl2 = cl2 + norm(wf2-wf1)/max(norm(wf1), norm(wf2));
+            denom = max(norm(wf1), norm(wf2));
+            if denom > 0
+                nSite = nSite + 1;
+                cl2 = cl2 + norm(wf2-wf1)/max(norm(wf1), norm(wf2));
+                % commenting out correlation; not currently used
+                % cv = cv + corr(wf1',wf2');  
+            end
         end
     end
 end


### PR DESCRIPTION
Fixing the L2 comparison to work with KS templates in place of calculated mean waveforms.